### PR TITLE
Fix README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Simple example:
 
 
 const mailer = require('anytv-mailer');
+const i18n = requier('anytv-i18n');
 
 
 // on server.js
@@ -33,15 +34,10 @@ mailer.configure({
         }
     },
 
-    i18n: {
-        languages_url: 'https://translation.server.com/:project/latest/languages.json',
-        translations_url: 'https://translation.server.com/:project/latest/:lang.json',
-        project: 'project_name',
-        default: 'en'
-    },
+    i18n: i18n,
 
     templates_dir: 'directory/of/templates',
-    
+
     /**
     *  This is optional, include this only when you're going to use
     *  .recommend_language


### PR DESCRIPTION
Changes:
- Updated instructions on how to use the library

anytv-mailer extends anytv-templater...

Before, templater hosts its own i18n, so it accepts the config for it.

Right now, templater does not have its own translator(i18n) anymore. It accepts a configured i18n object and uses it for translations. Passing the responsibility of loading i18n in the library user.